### PR TITLE
Change vlc package to vlc-nox

### DIFF
--- a/src/scripts/install_assistant.sh
+++ b/src/scripts/install_assistant.sh
@@ -8,7 +8,7 @@ echo ""
 echo "## Installing dependencies..."
 apt-get install python3 python3-dev python3-venv -y
 apt-get install portaudio19-dev libffi-dev libssl-dev -y
-apt-get install vlc -y
+apt-get install vlc-nox -y
 
 # Setup Virtual Environment
 echo "## Setting up Virtual Environment"


### PR DESCRIPTION
Change vlc package to vlc-nox to skip X11 installation on a headless system.
Package info: https://packages.debian.org/sv/jessie/vlc-nox
