### PR TITLE
Use PyPI version for python-vlc

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,6 @@
 requests>=2.13.0
 CherryPy>=10.1.1
-git+https://github.com/oaubert/python-vlc.git#egg=python-vlc
+python-vlc
 pyalsaaudio>=0.8.4
 webrtcvad>=2.0.10
 pyyaml


### PR DESCRIPTION
The github repo for python-vlc has a structure that will prevent its direct install from the requirements (the actual setup.py for the module is in generated/2.2). Use the PyPI version instead.

Closes #25 